### PR TITLE
fix(qq): wait for dispatcher queue to settle before retrying

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -2572,6 +2572,13 @@ ${current}
                                             globalDispatchError = err;
                                             console.error(`[QQ] Error during dispatchReplyFromConfig (attempt ${tryCount + 1}/${maxRetries + 1}):`, err);
                                         }
+                                        try {
+                                            // Reply dispatch is buffered; wait until queued deliveries settle
+                                            // before checking deliveredAnything/globalDispatchError for retry logic.
+                                            await dispatcher.waitForIdle();
+                                        } catch (idleErr) {
+                                            console.warn(`[QQ] Failed while waiting dispatcher idle: ${String(idleErr)}`);
+                                        }
                                         const dispatchDurationMs = Date.now() - dispatchStartTime;
                                         if (runState.isStale()) {
                                             break out_loop;
@@ -2630,6 +2637,12 @@ ${current}
                             console.error(`[QQ] Outer error:`, error);
                         }
                         finally {
+                            try {
+                                dispatcher.markComplete();
+                                await dispatcher.waitForIdle();
+                            } catch (idleErr) {
+                                console.warn(`[QQ] Failed during dispatcher completion: ${String(idleErr)}`);
+                            }
                             currentRunState = null;
                             clearProcessingTimers();
                             activeTaskIds.delete(taskKey);


### PR DESCRIPTION
## Summary
- wait for `dispatcher.waitForIdle()` right after `dispatchReplyFromConfig(...)`
- release dispatcher reservations with `dispatcher.markComplete()` in `finally`
- wait for idle again during completion to avoid stale delivery state

## Why
`dispatchReplyFromConfig` enqueues outbound deliveries asynchronously. The QQ retry loop was checking `deliveredAnything` / `dispatcherError` immediately after dispatch returned, which could happen before `deliver(...)` actually ran. In that race window, successful replies were treated as empty/error and retried, causing duplicate replies.

## Scope
- only `src/channel.ts`
- no behavior changes to image/media pipeline