### PR TITLE
优化了一下长文本截断发送的截断逻辑，同时避免发送时由于网络原因可能的乱序

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -223,7 +223,7 @@ function splitLongText(input: string, maxLength = 2800): string[] {
             cut = lastNewline;
         } else {
             // 特殊符号处截断
-            const sentencePattern = /[。！？；…\n\.!?;]/g;
+            const sentencePattern = /[。！？；…\n!?;]/g;
             let bestCut = -1;
             let match;
             while ((match = sentencePattern.exec(rest.slice(0, safeMaxLength + 50))) !== null) {
@@ -2475,7 +2475,7 @@ ${current}
                                         return i > 0;
                                     }
                                 } else {
-                                    // 目标字段异常时直接中止，避免继续发送造成不可预期乱序
+                                    // 目标字段异常时中止
                                     console.warn(`[QQ] Invalid chunk target context, abort chunk send: isGroup=${String(isGroup)} isGuild=${String(isGuild)} groupId=${String(groupId)} guildId=${String(guildId)} channelId=${String(channelId)} userId=${String(userId)}`);
                                     return i > 0;
                                 }


### PR DESCRIPTION
把截断方法更细化了一下，同时增加了发送时的Ack，避免乱序。
之前有可能出现这样的问题
<img width="384" height="82" alt="捕获" src="https://github.com/user-attachments/assets/815dd5e5-10ee-41c3-b3cf-f38d85cb915a" />
