### PR TITLE
fix: support string-shaped agent model config

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -3454,8 +3454,32 @@ ${current}
                         try {
                             const matchedAgentId = route.agentId;
                             const matchedAgentConfig = ((cfg as any).agents?.list || []).find((a: any) => a.id === matchedAgentId);
-                            const rawModelConfig = matchedAgentConfig?.model || (cfg as any).agents?.defaults?.model;
-                            const fallbacks = (typeof rawModelConfig === 'object' && Array.isArray(rawModelConfig.fallbacks)) ? rawModelConfig.fallbacks : [];
+                            // OpenClaw accepts either "provider/model" or
+                            // { primary, fallbacks } for agent model config.
+                            const normalizeModelConfig = (value: any) => {
+                                if (typeof value === "string") {
+                                    const primary = value.trim();
+                                    return primary ? { primary, fallbacks: [] as string[] } : undefined;
+                                }
+                                if (!value || typeof value !== "object") {
+                                    return undefined;
+                                }
+                                const primary = typeof value.primary === "string" ? value.primary.trim() : "";
+                                const fallbacks = Array.isArray(value.fallbacks)
+                                    ? value.fallbacks
+                                        .map((entry: any) => (typeof entry === "string" ? entry.trim() : ""))
+                                        .filter((entry: string) => Boolean(entry))
+                                    : [];
+                                if (!primary && fallbacks.length === 0) {
+                                    return undefined;
+                                }
+                                return { primary, fallbacks };
+                            };
+                            const rawModelConfig =
+                                normalizeModelConfig(matchedAgentConfig?.model) ||
+                                normalizeModelConfig((cfg as any).agents?.defaults?.model) ||
+                                { primary: "", fallbacks: [] as string[] };
+                            const fallbacks = rawModelConfig.fallbacks;
 
                             const modelsToTry = [null, ...fallbacks];
                             let globalDispatchError: any = null;
@@ -3467,6 +3491,12 @@ ${current}
                                 const modelToTest = modelsToTry[modelIndex] || rawModelConfig.primary;
                                 let currentCfg = cfg as any;
                                 if (runState.isStale()) {
+                                    break out_loop;
+                                }
+
+                                if (!modelToTest) {
+                                    globalDispatchError = new Error("[QQ] No model resolved for this route; check agents.<id>.model or agents.defaults.model");
+                                    console.error(globalDispatchError);
                                     break out_loop;
                                 }
 


### PR DESCRIPTION
## 变更说明

修复 `openclaw_qq` 在读取 `agents[*].model` 时只兼容对象写法、未兼容字符串写法的问题。

OpenClaw 当前支持两种合法配置：

```json
"model": "ollama/qwen3.5:9b"
```
或
```json

"model": {
  "primary": "ollama/qwen3.5:9b",
  "fallbacks": []
}
```
但 openclaw_qq 原来的实现默认把 model 当成 { primary, fallbacks } 来读取。
当实际配置为字符串时，插件会读不到 rawModelConfig.primary，导致主模型丢失。

在 QQ 路径下，这会进一步造成：

1. 已配置的主模型没有被正确传递
2. 运行时可能错误回退到 provider 下列出的第一个模型

例如: 实际配置是 ollama/qwen3.5:9b，但最终却跑到了 glm-4.7-flash
本次修改 ->
对 matchedAgentConfig?.model 和 agents?.defaults?.model 做统一规范化
同时兼容以下两种写法：
"provider/model"
{ primary, fallbacks }
当最终仍然无法解析出模型时，增加明确报错，避免静默退化到错误模型
修复效果
在如下配置下：
```jaon
{
  "agents": {
    "list": [
      {
        "id": "kakaxi",
        "model": "ollama/qwen3.5:9b"
      }
    ]
  }
}
```
QQ 插件会正确使用 ollama/qwen3.5:9b，不再错误落到 provider 模型列表中的第一个模型。